### PR TITLE
Require logger

### DIFF
--- a/lib/schedjewel.rb
+++ b/lib/schedjewel.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'logger'
 require 'memoist'
 require 'redis'
 require 'yaml'


### PR DESCRIPTION
Without this, the `Logger` constant we are using is undefined.