### PR TITLE
Remove prism from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ gemspec
 
 group :development, :test do
   gem 'bundler', require: false
-  # Source prism from GitHub for unreleased fixes, e.g. https://github.com/ruby/prism/pull/ 2563 .
-  gem 'prism', github: 'ruby/prism', require: false
   gem 'pry'
   gem 'pry-byebug'
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/ruby/prism.git
-  revision: 6a15e475c9512fdcbffacdf2cc9867ce7e3811c5
-  specs:
-    prism (0.24.0)
-
 PATH
   remote: .
   specs:
@@ -48,6 +42,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    prism (0.25.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -142,7 +137,6 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   bundler
-  prism!
   pry
   pry-byebug
   rspec


### PR DESCRIPTION
The fix that we were relying on should be included in the latest release. The RubyGems-sourced version is still indirectly included via `runger_style`.