### PR TITLE
Bump codecov/codecov-action from v3 to v4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Run RSpec tests
       run: bin/rspec --format progress
     - name: Upload Code Coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         directory: tmp/simple_cov
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This fixes a deprecation warning about "Node.js 16 actions are deprecated" and I think will also make coverage uploads more reliable.