### PR TITLE
[gemspec] Remove upper bounds on versions for all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove upper bounds on versions for all dependencies.
 
 ## v0.3.0 (2024-06-28)
 - Enforce only major and minor parts of required Ruby version (loosening the required Ruby version from 3.3.3 to 3.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     schedjewel (0.3.1.alpha)
-      memo_wise (>= 1.7, < 2)
+      memo_wise (>= 1.7)
       redis-client (~> 0.12)
       redlock (~> 2.0)
 

--- a/schedjewel.gemspec
+++ b/schedjewel.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency('memo_wise', '>= 1.7', '< 2')
+  spec.add_dependency('memo_wise', '>= 1.7')
   spec.add_dependency('redis-client', '~> 0.12')
   spec.add_dependency('redlock', '~> 2.0')
 


### PR DESCRIPTION
Let's optimistically assume that all future versions will be compatible. We can add restrictions or roll out a fix if that turns out not to be the case.

The upside of this change is that we don't have to make changes to this gem's gemspec to accommodate newly released versions of its dependencies.