### PR TITLE
Require 'forwardable'

### DIFF
--- a/lib/schedjewel/task.rb
+++ b/lib/schedjewel/task.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'forwardable'
 require 'json'
 require 'memo_wise'
 require 'securerandom'


### PR DESCRIPTION
Without this, there is a fatal exception when trying to boot `bin/console`:

```
❯ bin/console                                          
/home/david/code/schedjewel/lib/schedjewel/task.rb:8:in '<class:Task>': uninitialized constant Schedjewel::Task::Forwardable (NameError)

  extend Forwardable
         ^^^^^^^^^^^
	from /home/david/code/schedjewel/lib/schedjewel/task.rb:7:in '<top (required)>'
```