### PR TITLE
Require bundled default and test gems in spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,11 @@ SimpleCov.start do
   add_filter(%r{\A/spec/})
 end
 
+require 'bundler/setup'
+Bundler.require(:default, 'test')
+
 require_relative '../lib/schedjewel.rb'
+
 Dir['spec/support/**/*.rb'].each { |file| require("./#{file}") }
 require 'active_support'
 require 'active_support/testing/time_helpers'


### PR DESCRIPTION
This way, gems specified in the test section of the Gemfile will be automatically required when running specs (unless they have `require: false`). This is good because that is what I would expect, and we want to follow the principle of least surprise.