### PR TITLE
Remove manual require of the gem itself

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,6 @@ end
 require 'bundler/setup'
 Bundler.require(:default, :test)
 
-require_relative '../lib/schedjewel.rb'
-
 Dir['spec/support/**/*.rb'].each { |file| require("./#{file}") }
 require 'active_support'
 require 'active_support/testing/time_helpers'


### PR DESCRIPTION
This is not needed, because we have `Bundler.require(:default, :test)`, and we have `gemspec` in the default group of the `Gemfile`.